### PR TITLE
Add react-is, a secret dependecy of styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-helmet": "^6.1.0",
+        "react-is": "^17.0.2",
         "sass": "^1.32.11",
         "ssh2": "^0.8.9",
         "stream-browserify": "^3.0.0",
@@ -2009,16 +2010,16 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.5.tgz",
-      "integrity": "sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.5",
-        "@babel/parser": "^7.14.5",
+        "@babel/helpers": "^7.14.6",
+        "@babel/parser": "^7.14.6",
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
         "@babel/types": "^7.14.5",
@@ -2331,9 +2332,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
-      "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
       "dependencies": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
@@ -2357,9 +2358,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-      "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+      "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -8900,23 +8901,23 @@
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -9966,9 +9967,9 @@
       }
     },
     "node_modules/css-loader/node_modules/postcss": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.3.tgz",
-      "integrity": "sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
       "dependencies": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -10326,9 +10327,9 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/postcss": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.3.tgz",
-      "integrity": "sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
       "dependencies": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -22649,9 +22650,9 @@
       }
     },
     "node_modules/msw/node_modules/inquirer": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.0.tgz",
-      "integrity": "sha512-1nKYPoalt1vMBfCMtpomsUc32wmOoWXAoq3kM/5iTfxyQ2f/BxjixQpC+mbZ7BI0JUXHED4/XPXekDVtJNpXYw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
+      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -22695,9 +22696,9 @@
       }
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.0.tgz",
-      "integrity": "sha512-++0N6KyAj0t2webXst0PE0xuXb4Dv3z1Z+4SGzK+j/epeWBZCfkQbkW/ezscZwpinmBQ5wu/l4TqagKSVcAGCA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+      "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -25873,8 +25874,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -26069,9 +26069,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -34410,16 +34410,16 @@
       "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w=="
     },
     "@babel/core": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.5.tgz",
-      "integrity": "sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.5",
-        "@babel/parser": "^7.14.5",
+        "@babel/helpers": "^7.14.6",
+        "@babel/parser": "^7.14.6",
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
         "@babel/types": "^7.14.5",
@@ -34661,9 +34661,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
-      "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
       "requires": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
@@ -34681,9 +34681,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-      "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg=="
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+      "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.13.12",
@@ -39903,18 +39903,18 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -40749,9 +40749,9 @@
           }
         },
         "postcss": {
-          "version": "8.3.3",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.3.tgz",
-          "integrity": "sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==",
+          "version": "8.3.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+          "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
           "requires": {
             "colorette": "^1.2.2",
             "nanoid": "^3.1.23",
@@ -40988,9 +40988,9 @@
           }
         },
         "postcss": {
-          "version": "8.3.3",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.3.tgz",
-          "integrity": "sha512-gnXd9C4bGKevvlNFd80I8WfxHX+g6MR+W2h19PlDNHUuT9248rHTvCIDeZI3Hvs5mB3gzXiNDwVK3S153WJbZA==",
+          "version": "8.3.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+          "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
           "requires": {
             "colorette": "^1.2.2",
             "nanoid": "^3.1.23",
@@ -50393,9 +50393,9 @@
           "dev": true
         },
         "inquirer": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.0.tgz",
-          "integrity": "sha512-1nKYPoalt1vMBfCMtpomsUc32wmOoWXAoq3kM/5iTfxyQ2f/BxjixQpC+mbZ7BI0JUXHED4/XPXekDVtJNpXYw==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
+          "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -50430,9 +50430,9 @@
           }
         },
         "type-fest": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.0.tgz",
-          "integrity": "sha512-++0N6KyAj0t2webXst0PE0xuXb4Dv3z1Z+4SGzK+j/epeWBZCfkQbkW/ezscZwpinmBQ5wu/l4TqagKSVcAGCA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
           "dev": true
         },
         "yargs": {
@@ -52869,8 +52869,7 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -53022,9 +53021,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
+    "react-is": "^17.0.2",
     "sass": "^1.32.11",
     "ssh2": "^0.8.9",
     "stream-browserify": "^3.0.0",


### PR DESCRIPTION
Upgrading styled-components moved to a version where the maintainers accidentally dropped the react-is dependency